### PR TITLE
Remove img height check when printing images list

### DIFF
--- a/src/main/java/org/delaunois/brotherql/BrotherQLConnection.java
+++ b/src/main/java/org/delaunois/brotherql/BrotherQLConnection.java
@@ -463,7 +463,7 @@ public final class BrotherQLConnection implements Closeable {
         }
 
         for (BufferedImage image : images) {
-            if (image.getHeight() != bodyLengthPx || image.getWidth() != bodyWidthPx) {
+            if (image.getWidth() != bodyWidthPx) {
                 throw new BrotherQLException(String.format(Rx.msg("error.img.vary")));
             }
         }

--- a/src/main/java/org/delaunois/brotherql/BrotherQLConnection.java
+++ b/src/main/java/org/delaunois/brotherql/BrotherQLConnection.java
@@ -463,7 +463,7 @@ public final class BrotherQLConnection implements Closeable {
         }
 
         for (BufferedImage image : images) {
-            if (image.getWidth() != bodyWidthPx) {
+            if (image.getHeight() != bodyLengthPx || image.getWidth() != bodyWidthPx) {
                 throw new BrotherQLException(String.format(Rx.msg("error.img.vary")));
             }
         }

--- a/src/main/java/org/delaunois/brotherql/BrotherQLConnection.java
+++ b/src/main/java/org/delaunois/brotherql/BrotherQLConnection.java
@@ -463,7 +463,9 @@ public final class BrotherQLConnection implements Closeable {
         }
 
         for (BufferedImage image : images) {
-            if (image.getHeight() != bodyLengthPx || image.getWidth() != bodyWidthPx) {
+            boolean isContinuous = BrotherQLMediaType.CONTINUOUS_LENGTH_TAPE.equals(media.mediaType);
+            if ((!isContinuous && (image.getHeight() != bodyLengthPx || image.getWidth() != bodyWidthPx)) ||
+                    (isContinuous && (image.getWidth() != bodyWidthPx))) {
                 throw new BrotherQLException(String.format(Rx.msg("error.img.vary")));
             }
         }


### PR DESCRIPTION
Hi,
we are using the library to print receipts by passing multiple BufferedImages to the print job.
These images often have different heights, since they include product lists of varying lengths.
In such cases, we receive errors and the print job cannot be completed.

I removed the height check, and with this change, printing works correctly for our use cases.
Could you please review this fix and consider merging it?

Thank you very much, and greetings from Italy!
Best regards,
Marco